### PR TITLE
Collect stargazer numbers for each month

### DIFF
--- a/src/main/graphql/io/spring/team/scorecard/Stargazers.graphql
+++ b/src/main/graphql/io/spring/team/scorecard/Stargazers.graphql
@@ -1,0 +1,13 @@
+query Stargazers($org: String!, $repo: String!, $after: String) {
+	repository(owner: $org, name: $repo) {
+		stargazers(first: 100, after: $after) {    
+			edges {
+				starredAt
+			}
+			pageInfo {
+				hasNextPage
+				endCursor
+			}
+		}
+	}
+}

--- a/src/main/java/io/spring/team/scorecard/ScoreCardApplicationRunner.java
+++ b/src/main/java/io/spring/team/scorecard/ScoreCardApplicationRunner.java
@@ -30,6 +30,7 @@ public class ScoreCardApplicationRunner implements ApplicationRunner {
 
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
+		this.statsService.stargazers();
 		LocalDate start = parseDate("start", args.getOptionValues("start"));
 		LocalDate end = parseDate("end", args.getOptionValues("end"));
 		logger.info("Stats for: " + this.properties.getProject().getRepository() + " " + start.toString() + " -> " + end.toString());

--- a/src/main/java/io/spring/team/scorecard/graphql/GraphQLClient.java
+++ b/src/main/java/io/spring/team/scorecard/graphql/GraphQLClient.java
@@ -1,6 +1,8 @@
 package io.spring.team.scorecard.graphql;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloClient;
@@ -8,6 +10,12 @@ import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 import io.spring.team.scorecard.AssignableUsersQuery;
 import io.spring.team.scorecard.IssueCountQuery;
+import io.spring.team.scorecard.StargazersQuery;
+import io.spring.team.scorecard.StargazersQuery.Builder;
+import io.spring.team.scorecard.StargazersQuery.Data;
+import io.spring.team.scorecard.StargazersQuery.Edge;
+import io.spring.team.scorecard.StargazersQuery.PageInfo;
+import io.spring.team.scorecard.StargazersQuery.Stargazers;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -15,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 
 public class GraphQLClient {
@@ -31,7 +40,54 @@ public class GraphQLClient {
 				.okHttpClient(clientBuilder.build())
 				.build();
 	}
+	
+	public Flux<OffsetDateTime> stargazers(String org, String repo) {
+		return stargazers(org, repo, null);
+	}
+	
+	private Flux<OffsetDateTime> stargazers(String org, String repo, String after) {
+		return Flux.create(sink -> {
+			stargazers(org, repo, after, sink);
+			
+		});
+		
+	}
 
+	private void stargazers(String org, String repo, String after, FluxSink<OffsetDateTime> sink) {
+		Builder builder = StargazersQuery.builder().org(org).repo(repo);
+		if (after != null) {
+			builder = builder.after(after);
+		}
+		this.apolloClient.query(builder.build()).enqueue(new ApolloCall.Callback<StargazersQuery.Data>() {
+
+			@Override
+			public void onResponse(Response<Data> response) {
+				Stargazers stargazers = response.getData().repository().stargazers();
+				stargazers.edges().stream()
+						.map(Edge::starredAt)
+						.map(String.class::cast)
+						.map(GraphQLClient.this::parse)
+						.forEach(sink::next);;					
+				PageInfo pageInfo = stargazers.pageInfo();
+				if (pageInfo.hasNextPage()) {
+					stargazers(org, repo, pageInfo.endCursor(), sink);
+				}
+				else {
+					sink.complete();
+				}
+			}
+
+			@Override
+			public void onFailure(ApolloException ex) {
+				sink.error(ex);
+			}
+			
+		});
+	}
+	
+	private OffsetDateTime parse(String input) {
+		return OffsetDateTime.parse(input, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+	}
 
 	public Mono<Integer> searchNumberOfIssuesAndPRs(String searchQuery) {
 		logger.debug("query: " + searchQuery);

--- a/src/main/java/io/spring/team/scorecard/stats/StatsService.java
+++ b/src/main/java/io/spring/team/scorecard/stats/StatsService.java
@@ -1,7 +1,10 @@
 package io.spring.team.scorecard.stats;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import io.spring.team.scorecard.graphql.GraphQLClient;
 import io.spring.team.scorecard.graphql.SearchQueryBuilder;
@@ -20,6 +23,14 @@ public class StatsService {
 		this.org = org;
 		this.repo = repo;
 		this.client = client;
+	}
+	
+	public void stargazers() {
+		List<OffsetDateTime> stargazers = this.client.stargazers(this.org, this.repo).collectList().block();
+		IntStream.range(1, 13).forEachOrdered((month) -> {
+			YearMonth yearMonth = YearMonth.of(2020,  month);
+			System.out.println(yearMonth + ": " + stargazers.stream().filter((starredAt) -> !starredAt.toLocalDate().isAfter(yearMonth.atEndOfMonth())).count());
+		});
 	}
 
 	/**


### PR DESCRIPTION
Hey, Brian. This is very much a draft. To be efficient, it gets all of the stargazer data for a repository once and then processes it to get the numbers for each month. In other words, it isn't suited to being used as a CLI tool with `--start` and `--end` as the time taken to get the star gazing data is prohibitively slow.

I'd be happy to help to make some changes to work the retrieval of the star gazing data into the tool, but I think it'd require a change in the tool's approach.