### PR TITLE
Exit when done

### DIFF
--- a/src/main/java/io/spring/team/scorecard/ScorecardApplication.java
+++ b/src/main/java/io/spring/team/scorecard/ScorecardApplication.java
@@ -3,13 +3,17 @@ package io.spring.team.scorecard;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ConfigurableApplicationContext;
 
 @SpringBootApplication
 @EnableConfigurationProperties(ScorecardProperties.class)
 public class ScorecardApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(ScorecardApplication.class, args);
+		ConfigurableApplicationContext ctx =
+				SpringApplication.run(ScorecardApplication.class, args);
+		ctx.close();
+		System.exit(0);
 	}
 
 }


### PR DESCRIPTION
This commit forces the application to exit once it has printed the stats.

Roughly works around https://github.com/apollographql/apollo-android/issues/1896

`ctx.close()` seems to be sufficient in principle, but it takes a long time to exit, probably due to some TTLs or grace shutdown period.