### PR TITLE
Alternative service oriented towards single query for workload

### DIFF
--- a/src/main/graphql/io/spring/team/scorecard/IssueData.graphql
+++ b/src/main/graphql/io/spring/team/scorecard/IssueData.graphql
@@ -1,0 +1,51 @@
+query IssueData($query: String!) {
+    search(query: $query, type: ISSUE, last: 100) {
+        issueCount
+        nodes {
+            ... on Issue {
+                number
+                state
+                author {
+                    login
+                }
+                labels(last: 10) {
+                    nodes {
+                        name
+                    }
+                }
+                milestone {
+                    title
+                }
+                participants(last: 10) {
+                    nodes {
+                        login
+                    }
+                }
+                createdAt
+                closedAt
+            }
+            ... on PullRequest {
+                number
+                state
+                author {
+                    login
+                }
+                labels(last: 10) {
+                    nodes {
+                        name
+                    }
+                }
+                milestone {
+                    title
+                }
+                participants(last: 10) {
+                    nodes {
+                        login
+                    }
+                }
+                createdAt
+                closedAt
+            }
+        }
+    }
+}

--- a/src/main/graphql/io/spring/team/scorecard/IssueData.graphql
+++ b/src/main/graphql/io/spring/team/scorecard/IssueData.graphql
@@ -1,5 +1,5 @@
-query IssueData($query: String!) {
-    search(query: $query, type: ISSUE, last: 100) {
+query IssueData($query: String!, $cursor: String) {
+    search(query: $query, type: ISSUE, first: 100, after: $cursor) {
         issueCount
         nodes {
             ... on Issue {
@@ -46,6 +46,10 @@ query IssueData($query: String!) {
                 createdAt
                 closedAt
             }
+        }
+        pageInfo {
+            endCursor
+            hasNextPage
         }
     }
 }

--- a/src/main/java/io/spring/team/scorecard/ScoreCardApplicationRunner.java
+++ b/src/main/java/io/spring/team/scorecard/ScoreCardApplicationRunner.java
@@ -5,11 +5,13 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import io.spring.team.scorecard.data.Issue;
+import io.spring.team.scorecard.data.Stats;
 import io.spring.team.scorecard.stats.StatsService;
 import io.spring.team.scorecard.stats.StatsService2;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
 
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -44,53 +46,75 @@ public class ScoreCardApplicationRunner implements ApplicationRunner {
 		List<String> assignableUsers = this.statsServiceDedicatedQuery.findAssignableUsers().collectList().block();
 		logger.info("Assignable Users: " + StringUtils.collectionToCommaDelimitedString(assignableUsers));
 
-		List<Issue> issues = this.statsServiceInMemory.findAllIssuesCreatedBetween(start, end)
-				.collectList().block();
-		logger.debug("Found " + issues.size() + " issues: " + issues.stream().map(i -> "#" + i.id).collect(Collectors.joining(", ")));
+		Mono<Stats> singleQuery = Mono.just(new Stats())
+				.flatMap(stats -> this.statsServiceInMemory.findAllIssuesCreatedBetween(start, end)
+						.collectList()
+						.doOnNext(createdIssues -> logger.trace("Found " + createdIssues.size() + " created issues in the period: " + createdIssues.stream().map(i -> "#" + i.id).collect(Collectors.joining(", "))))
+						.map(createdIssues -> {
+							stats.setTeamCreated(this.statsServiceInMemory.teamCreated(createdIssues, this.properties.getProject().getMembers()));
+							stats.setCommunityCreated(this.statsServiceInMemory.calculateInboundVolume(createdIssues, this.properties.getProject().getMembers(), this.properties.getProject().getBots()));
+							return stats;
+						})
+				)
+				.flatMap(stats -> this.statsServiceInMemory.findAllIssuesClosedBetween(start, end)
+						.collectList()
+						.doOnNext(closedIssues -> logger.trace("Found " + closedIssues.size() + " issues in the period: " + closedIssues.stream().map(i -> "#" + i.id).collect(Collectors.joining(", "))))
+						.map(closedIssues -> {
+							stats.setClosedAsDuplicates(this.statsServiceInMemory.calculateOutputVolumeByType(closedIssues, this.properties.getLabels().getDuplicates()));
+							stats.setClosedAsQuestions(this.statsServiceInMemory.calculateOutputVolumeByType(closedIssues, this.properties.getLabels().getQuestions()));
+							stats.setClosedAsDeclined(this.statsServiceInMemory.calculateOutputVolumeByType(closedIssues, this.properties.getLabels().getRejected()));
+							stats.setClosedAsEnhancements(this.statsServiceInMemory.calculateOutputVolumeByType(closedIssues, this.properties.getLabels().getEnhancements()));
+							stats.setClosedAsPort(this.statsServiceInMemory.calculateOutputVolumeByType(closedIssues, this.properties.getLabels().getPorts()));
+							stats.setClosedAsBug(this.statsServiceInMemory.calculateOutputVolumeByType(closedIssues, this.properties.getLabels().getBugs()));
+							stats.setClosedAsTask( this.statsServiceInMemory.calculateOutputVolumeByType(closedIssues, this.properties.getLabels().getTasks()));
+							stats.setClosedAsDocumentation(this.statsServiceInMemory.calculateOutputVolumeByType(closedIssues, this.properties.getLabels().getDocs()));
+							return stats;
+						})
+				);
 
-		long teamCreated2 = this.statsServiceInMemory.teamCreated(issues, this.properties.getProject().getMembers());
-		long communityCreated2 = this.statsServiceInMemory.calculateInboundVolume(issues, this.properties.getProject().getMembers(), this.properties.getProject().getBots());
-		long closedAsDuplicates2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getDuplicates());
-		long closedAsQuestions2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getQuestions());
-		long closedAsDeclined2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getRejected());
-		long closedAsEnhancements2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getEnhancements());
-		long closedAsPort2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getPorts());
-		long closedAsBug2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getBugs());
-		long closedAsTask2 =  this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getTasks());
-		long closedAsDocumentation2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getDocs());
+		Mono<Stats> fanIn = Mono.just(new Stats())
+				.flatMap(stats -> this.statsServiceDedicatedQuery.teamCreated(start, end, this.properties.getProject().getMembers())
+						.map(stats::setTeamCreated))
+				.flatMap(stats -> this.statsServiceDedicatedQuery.calculateInboundVolume(start, end, this.properties.getProject().getMembers(),
+						this.properties.getProject().getBots())
+						.map(stats::setCommunityCreated))
+				.flatMap(stats -> this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getDuplicates())
+						.map(stats::setClosedAsDuplicates))
+				.flatMap(stats -> this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getQuestions())
+						.map(stats::setClosedAsQuestions))
+				.flatMap(stats -> this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getRejected())
+						.map(stats::setClosedAsDeclined))
+				.flatMap(stats -> this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getEnhancements())
+						.map(stats::setClosedAsEnhancements))
+				.flatMap(stats -> this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getPorts())
+						.map(stats::setClosedAsPort))
+				.flatMap(stats -> this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getBugs())
+						.map(stats::setClosedAsBug))
+				.flatMap(stats ->  this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getTasks())
+						.map(stats::setClosedAsTask))
+				.flatMap(stats -> this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getDocs())
+						.map(stats::setClosedAsDocumentation));
 
+		final Tuple2<Stats, Stats> bothStats = Mono.zip(singleQuery, fanIn).block();
+		Stats singleQueryStats = bothStats.getT1();
+		Stats fanInStats = bothStats.getT2();
 
-		long teamCreatedDedicatedQuery = this.statsServiceDedicatedQuery.teamCreated(start, end, this.properties.getProject().getMembers()).block();
-		long communityCreatedDedicatedQuery = this.statsServiceDedicatedQuery.calculateInboundVolume(start, end, this.properties.getProject().getMembers(), this.properties.getProject().getBots()).block();
-		long closedAsDuplicatesDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getDuplicates()).block();
-		long closedAsQuestionsDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getQuestions()).block();
-		long closedAsDeclinedDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getRejected()).block();
-		long closedAsEnhancementsDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getEnhancements()).block();
-		long closedAsPortDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getPorts()).block();
-		long closedAsBugDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getBugs()).block();
-		long closedAsTaskDedicatedQuery =  this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getTasks()).block();
-		long closedAsDocumentationDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getDocs()).block();
-
-
-		checkConsistent("Team created", teamCreatedDedicatedQuery, teamCreated2);
-		checkConsistent("Community created (Inbound Volume)", communityCreatedDedicatedQuery, communityCreated2);
-		checkConsistent("Closed as Duplicates", closedAsDuplicatesDedicatedQuery, closedAsDuplicates2);
-		checkConsistent("Closed as Questions", closedAsQuestionsDedicatedQuery, closedAsQuestions2);
-		checkConsistent("Closed as Declined", closedAsDeclinedDedicatedQuery, closedAsDeclined2);
-		checkConsistent("Closed as Enhancements", closedAsEnhancementsDedicatedQuery, closedAsEnhancements2);
-		checkConsistent("Closed as Back/Forward-port", closedAsPortDedicatedQuery, closedAsPort2);
-		checkConsistent("Closed as Bug/Regression", closedAsBugDedicatedQuery, closedAsBug2);
-		checkConsistent("Closed as Task/Dependency Upgrade", closedAsTaskDedicatedQuery, closedAsTask2);
-		checkConsistent("Closed as Documentation", closedAsDocumentationDedicatedQuery, closedAsDocumentation2);
-	}
-
-	private void checkConsistent(String label, long method1, long method2) {
-		if (method1 != method2) {
-			logger.warn(label + ": inconsistent data between methods, got " + method1 + " and " + method2);
+		final List<String> inconsistencies = fanInStats.checkInconsistencies(singleQueryStats);
+		if (!inconsistencies.isEmpty()) {
+			logger.warn("Inconsistencies found between two methods: " + String.join(", ", inconsistencies));
 		}
-		logger.info(label + ": " + method1);
-	}
 
+		logger.info("Team created: " + singleQueryStats.getTeamCreated());
+		logger.info("Community created (Inbound Volume): " + singleQueryStats.getCommunityCreated());
+		logger.info("Closed as Duplicates: " + singleQueryStats.getClosedAsDuplicates());
+		logger.info("Closed as Questions: " + singleQueryStats.getClosedAsQuestions());
+		logger.info("Closed as Declined: " + singleQueryStats.getClosedAsDeclined());
+		logger.info("Closed as Enhancements: " + singleQueryStats.getClosedAsEnhancements());
+		logger.info("Closed as Back/Forward-port: " + singleQueryStats.getClosedAsPort());
+		logger.info("Closed as Bug/Regression: " + singleQueryStats.getClosedAsBug());
+		logger.info("Closed as Task/Dependency Upgrade: " + singleQueryStats.getClosedAsTask());
+		logger.info("Closed as Documentation: " + singleQueryStats.getClosedAsDocumentation());
+	}
 
 	private LocalDate parseDate(String name, List<String> argument) {
 		Assert.state(argument != null && StringUtils.hasText(argument.get(0)),

--- a/src/main/java/io/spring/team/scorecard/ScoreCardApplicationRunner.java
+++ b/src/main/java/io/spring/team/scorecard/ScoreCardApplicationRunner.java
@@ -3,8 +3,11 @@ package io.spring.team.scorecard;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import io.spring.team.scorecard.data.Issue;
 import io.spring.team.scorecard.stats.StatsService;
+import io.spring.team.scorecard.stats.StatsService2;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -19,12 +22,14 @@ public class ScoreCardApplicationRunner implements ApplicationRunner {
 
 	private static Log logger = LogFactory.getLog(ScoreCardApplicationRunner.class);
 
-	private final StatsService statsService;
+	private final StatsService statsServiceDedicatedQuery;
+	private final StatsService2 statsServiceInMemory;
 
 	private final ScorecardProperties properties;
 
-	public ScoreCardApplicationRunner(StatsService statsService, ScorecardProperties properties) {
-		this.statsService = statsService;
+	public ScoreCardApplicationRunner(StatsService statsServiceDedicatedQuery, StatsService2 statsServiceInMemory, ScorecardProperties properties) {
+		this.statsServiceDedicatedQuery = statsServiceDedicatedQuery;
+		this.statsServiceInMemory = statsServiceInMemory;
 		this.properties = properties;
 	}
 
@@ -36,20 +41,54 @@ public class ScoreCardApplicationRunner implements ApplicationRunner {
 
 		logger.info("Team members: " + StringUtils.collectionToCommaDelimitedString(this.properties.getProject().getMembers()));
 		logger.info("Team bots: " + StringUtils.collectionToCommaDelimitedString(this.properties.getProject().getBots()));
-		List<String> assignableUsers = this.statsService.findAssignableUsers().collectList().block();
+		List<String> assignableUsers = this.statsServiceDedicatedQuery.findAssignableUsers().collectList().block();
 		logger.info("Assignable Users: " + StringUtils.collectionToCommaDelimitedString(assignableUsers));
-		logger.info("Team created: " + this.statsService.teamCreated(start, end,
-				this.properties.getProject().getMembers()).block());
-		logger.info("Community created (Inbound Volume): " + this.statsService.calculateInboundVolume(start, end,
-				this.properties.getProject().getMembers(), this.properties.getProject().getBots()).block());
-		logger.info("Closed as Duplicates: " + this.statsService.calculateOutputVolumeByType(start, end, this.properties.getLabels().getDuplicates()).block());
-		logger.info("Closed as Questions: " + this.statsService.calculateOutputVolumeByType(start, end, this.properties.getLabels().getQuestions()).block());
-		logger.info("Closed as Declined: " + this.statsService.calculateOutputVolumeByType(start, end, this.properties.getLabels().getRejected()).block());
-		logger.info("Closed as Enhancements: " + this.statsService.calculateOutputVolumeByType(start, end, this.properties.getLabels().getEnhancements()).block());
-		logger.info("Closed as Back/Forward-port: " + this.statsService.calculateOutputVolumeByType(start, end, this.properties.getLabels().getPorts()).block());
-		logger.info("Closed as Bug/Regression: " + this.statsService.calculateOutputVolumeByType(start, end, this.properties.getLabels().getBugs()).block());
-		logger.info("Closed as Task/Dependency Upgrade: " + this.statsService.calculateOutputVolumeByType(start, end, this.properties.getLabels().getTasks()).block());
-		logger.info("Closed as Documentation: " + this.statsService.calculateOutputVolumeByType(start, end, this.properties.getLabels().getDocs()).block());
+
+		List<Issue> issues = this.statsServiceInMemory.findAllIssuesCreatedBetween(start, end)
+				.collectList().block();
+		logger.debug("Found " + issues.size() + " issues: " + issues.stream().map(i -> "#" + i.id).collect(Collectors.joining(", ")));
+
+		long teamCreated2 = this.statsServiceInMemory.teamCreated(issues, this.properties.getProject().getMembers());
+		long communityCreated2 = this.statsServiceInMemory.calculateInboundVolume(issues, this.properties.getProject().getMembers(), this.properties.getProject().getBots());
+		long closedAsDuplicates2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getDuplicates());
+		long closedAsQuestions2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getQuestions());
+		long closedAsDeclined2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getRejected());
+		long closedAsEnhancements2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getEnhancements());
+		long closedAsPort2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getPorts());
+		long closedAsBug2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getBugs());
+		long closedAsTask2 =  this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getTasks());
+		long closedAsDocumentation2 = this.statsServiceInMemory.calculateOutputVolumeByType(issues, this.properties.getLabels().getDocs());
+
+
+		long teamCreatedDedicatedQuery = this.statsServiceDedicatedQuery.teamCreated(start, end, this.properties.getProject().getMembers()).block();
+		long communityCreatedDedicatedQuery = this.statsServiceDedicatedQuery.calculateInboundVolume(start, end, this.properties.getProject().getMembers(), this.properties.getProject().getBots()).block();
+		long closedAsDuplicatesDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getDuplicates()).block();
+		long closedAsQuestionsDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getQuestions()).block();
+		long closedAsDeclinedDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getRejected()).block();
+		long closedAsEnhancementsDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getEnhancements()).block();
+		long closedAsPortDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getPorts()).block();
+		long closedAsBugDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getBugs()).block();
+		long closedAsTaskDedicatedQuery =  this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getTasks()).block();
+		long closedAsDocumentationDedicatedQuery = this.statsServiceDedicatedQuery.calculateOutputVolumeByType(start, end, this.properties.getLabels().getDocs()).block();
+
+
+		checkConsistent("Team created", teamCreatedDedicatedQuery, teamCreated2);
+		checkConsistent("Community created (Inbound Volume)", communityCreatedDedicatedQuery, communityCreated2);
+		checkConsistent("Closed as Duplicates", closedAsDuplicatesDedicatedQuery, closedAsDuplicates2);
+		checkConsistent("Closed as Questions", closedAsQuestionsDedicatedQuery, closedAsQuestions2);
+		checkConsistent("Closed as Declined", closedAsDeclinedDedicatedQuery, closedAsDeclined2);
+		checkConsistent("Closed as Enhancements", closedAsEnhancementsDedicatedQuery, closedAsEnhancements2);
+		checkConsistent("Closed as Back/Forward-port", closedAsPortDedicatedQuery, closedAsPort2);
+		checkConsistent("Closed as Bug/Regression", closedAsBugDedicatedQuery, closedAsBug2);
+		checkConsistent("Closed as Task/Dependency Upgrade", closedAsTaskDedicatedQuery, closedAsTask2);
+		checkConsistent("Closed as Documentation", closedAsDocumentationDedicatedQuery, closedAsDocumentation2);
+	}
+
+	private void checkConsistent(String label, long method1, long method2) {
+		if (method1 != method2) {
+			logger.warn(label + ": inconsistent data between methods, got " + method1 + " and " + method2);
+		}
+		logger.info(label + ": " + method1);
 	}
 
 

--- a/src/main/java/io/spring/team/scorecard/ScoreCardConfig.java
+++ b/src/main/java/io/spring/team/scorecard/ScoreCardConfig.java
@@ -2,6 +2,7 @@ package io.spring.team.scorecard;
 
 import io.spring.team.scorecard.graphql.GraphQLClient;
 import io.spring.team.scorecard.stats.StatsService;
+import io.spring.team.scorecard.stats.StatsService2;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,5 +18,10 @@ public class ScoreCardConfig {
 	@Bean
 	public StatsService statsService(ScorecardProperties properties, GraphQLClient graphQLClient) {
 		return new StatsService(properties.getProject().getOrg(), properties.getProject().getName(), graphQLClient);
+	}
+
+	@Bean
+	public StatsService2 statsService2(ScorecardProperties properties, GraphQLClient graphQLClient) {
+		return new StatsService2(properties.getProject().getOrg(), properties.getProject().getName(), graphQLClient);
 	}
 }

--- a/src/main/java/io/spring/team/scorecard/ScorecardProperties.java
+++ b/src/main/java/io/spring/team/scorecard/ScorecardProperties.java
@@ -1,6 +1,7 @@
 package io.spring.team.scorecard;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 

--- a/src/main/java/io/spring/team/scorecard/data/Issue.java
+++ b/src/main/java/io/spring/team/scorecard/data/Issue.java
@@ -1,0 +1,44 @@
+package io.spring.team.scorecard.data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * @author Simon Baslé
+ */
+public class Issue {
+
+	public final int id;
+	public final String author;
+	public final LocalDateTime createdAt;
+	public final boolean isOpen;
+	public final LocalDateTime closedAt;
+	public final List<String> labels;
+	public final List<String> participants;
+	public final String milestone;
+
+	public Issue(int id, String author, LocalDateTime createdAt, boolean isOpen, LocalDateTime closedAt, List<String> labels, List<String> participants, String milestone) {
+		this.id = id;
+		this.author = author;
+		this.createdAt = createdAt;
+		this.isOpen = isOpen;
+		this.closedAt = closedAt;
+		this.labels = labels;
+		this.participants = participants;
+		this.milestone = milestone;
+	}
+
+	@Override
+	public String toString() {
+		return "Issue{" +
+				"id=" + id +
+				", author='" + author + '\'' +
+				", createdAt=" + createdAt +
+				", isOpen=" + isOpen +
+				", closedAt=" + closedAt +
+				", labels=" + labels +
+				", participants=" + participants +
+				", milestone='" + milestone + '\'' +
+				'}';
+	}
+}

--- a/src/main/java/io/spring/team/scorecard/data/Stats.java
+++ b/src/main/java/io/spring/team/scorecard/data/Stats.java
@@ -1,0 +1,202 @@
+package io.spring.team.scorecard.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Mutable stats accumulator
+ *
+ * @author Simon Baslé
+ */
+public class Stats {
+
+	private long teamCreated;
+	private long communityCreated;
+	private long closedAsDuplicates;
+	private long closedAsQuestions;
+	private long closedAsDeclined;
+	private long closedAsEnhancements;
+	private long closedAsPort;
+	private long closedAsBug;
+	private long closedAsTask;
+	private long closedAsDocumentation;
+
+	public long getTeamCreated() {
+		return teamCreated;
+	}
+
+	public Stats setTeamCreated(long teamCreated) {
+		this.teamCreated = teamCreated;
+		return this;
+	}
+
+	public long getCommunityCreated() {
+		return communityCreated;
+	}
+
+	public Stats setCommunityCreated(long communityCreated) {
+		this.communityCreated = communityCreated;
+		return this;
+	}
+
+	public long getClosedAsDuplicates() {
+		return closedAsDuplicates;
+	}
+
+	public Stats setClosedAsDuplicates(long closedAsDuplicates) {
+		this.closedAsDuplicates = closedAsDuplicates;
+		return this;
+	}
+
+	public long getClosedAsQuestions() {
+		return closedAsQuestions;
+	}
+
+	public Stats setClosedAsQuestions(long closedAsQuestions) {
+		this.closedAsQuestions = closedAsQuestions;
+		return this;
+	}
+
+	public long getClosedAsDeclined() {
+		return closedAsDeclined;
+	}
+
+	public Stats setClosedAsDeclined(long closedAsDeclined) {
+		this.closedAsDeclined = closedAsDeclined;
+		return this;
+	}
+
+	public long getClosedAsEnhancements() {
+		return closedAsEnhancements;
+	}
+
+	public Stats setClosedAsEnhancements(long closedAsEnhancements) {
+		this.closedAsEnhancements = closedAsEnhancements;
+		return this;
+	}
+
+	public long getClosedAsPort() {
+		return closedAsPort;
+	}
+
+	public Stats setClosedAsPort(long closedAsPort) {
+		this.closedAsPort = closedAsPort;
+		return this;
+	}
+
+	public long getClosedAsBug() {
+		return closedAsBug;
+	}
+
+	public Stats setClosedAsBug(long closedAsBug) {
+		this.closedAsBug = closedAsBug;
+		return this;
+	}
+
+	public long getClosedAsTask() {
+		return closedAsTask;
+	}
+
+	public Stats setClosedAsTask(long closedAsTask) {
+		this.closedAsTask = closedAsTask;
+		return this;
+	}
+
+	public long getClosedAsDocumentation() {
+		return closedAsDocumentation;
+	}
+
+	public Stats setClosedAsDocumentation(long closedAsDocumentation) {
+		this.closedAsDocumentation = closedAsDocumentation;
+		return this;
+	}
+
+	public List<String> checkInconsistencies(Stats stats) {
+		List<String> inconsistencies = new ArrayList<>();
+		long thisValue = this.getTeamCreated();
+		long otherValue = stats.getTeamCreated();
+		if (thisValue != otherValue) {
+			inconsistencies.add("teamCreated(" + thisValue + " vs " + otherValue + ")");
+		}
+
+		thisValue = this.getCommunityCreated();
+		otherValue = stats.getCommunityCreated();
+		if (thisValue != otherValue) {
+			inconsistencies.add("communityCreated(" + thisValue + " vs " + otherValue + ")");
+		}
+
+		thisValue = this.getClosedAsDuplicates();
+		otherValue = stats.getClosedAsDuplicates();
+		if (thisValue != otherValue) {
+			inconsistencies.add("closedAsDuplicates(" + thisValue + " vs " + otherValue + ")");
+		}
+
+				thisValue = this.getClosedAsQuestions();
+		otherValue = stats.getClosedAsQuestions();
+		if (thisValue != otherValue) {
+			inconsistencies.add("closedAsQuestions(" + thisValue + " vs " + otherValue + ")");
+		}
+
+		thisValue = this.getClosedAsDeclined();
+		otherValue = stats.getClosedAsDeclined();
+		if (thisValue != otherValue) {
+			inconsistencies.add("closedAsDeclined(" + thisValue + " vs " + otherValue + ")");
+		}
+
+		thisValue = this.getClosedAsEnhancements();
+		otherValue = stats.getClosedAsEnhancements();
+		if (thisValue != otherValue) {
+			inconsistencies.add("closedAsEnhancements(" + thisValue + " vs " + otherValue + ")");
+		}
+
+		thisValue = this.getClosedAsPort();
+		otherValue = stats.getClosedAsPort();
+		if (thisValue != otherValue) {
+			inconsistencies.add("closedAsPort(" + thisValue + " vs " + otherValue + ")");
+		}
+
+		thisValue = this.getClosedAsBug();
+		otherValue = stats.getClosedAsBug();
+		if (thisValue != otherValue) {
+			inconsistencies.add("closedAsBug(" + thisValue + " vs " + otherValue + ")");
+		}
+
+		thisValue = this.getClosedAsTask();
+		otherValue = stats.getClosedAsTask();
+		if (thisValue != otherValue) {
+			inconsistencies.add("closedAsTask(" + thisValue + " vs " + otherValue + ")");
+		}
+
+		thisValue = this.getClosedAsDocumentation();
+		otherValue = stats.getClosedAsDocumentation();
+		if (thisValue != otherValue) {
+			inconsistencies.add("closedAsDocumentation(" + thisValue + " vs " + otherValue + ")");
+		}
+
+		return inconsistencies;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Stats stats = (Stats) o;
+		return getTeamCreated() == stats.getTeamCreated() &&
+				getCommunityCreated() == stats.getCommunityCreated() &&
+				getClosedAsDuplicates() == stats.getClosedAsDuplicates() &&
+				getClosedAsQuestions() == stats.getClosedAsQuestions() &&
+				getClosedAsDeclined() == stats.getClosedAsDeclined() &&
+				getClosedAsEnhancements() == stats.getClosedAsEnhancements() &&
+				getClosedAsPort() == stats.getClosedAsPort() &&
+				getClosedAsBug() == stats.getClosedAsBug() &&
+				getClosedAsTask() == stats.getClosedAsTask() &&
+				getClosedAsDocumentation() == stats.getClosedAsDocumentation();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects
+				.hash(getTeamCreated(), getCommunityCreated(), getClosedAsDuplicates(), getClosedAsQuestions(), getClosedAsDeclined(), getClosedAsEnhancements(), getClosedAsPort(), getClosedAsBug(), getClosedAsTask(), getClosedAsDocumentation());
+	}
+}

--- a/src/main/java/io/spring/team/scorecard/graphql/GraphQLClient.java
+++ b/src/main/java/io/spring/team/scorecard/graphql/GraphQLClient.java
@@ -91,13 +91,11 @@ public class GraphQLClient {
 
 				boolean hasMorePages = search.pageInfo().hasNextPage();
 				if (hasMorePages) {
-					logger.debug("Fetching additional page");
 					String nextCursor = search.pageInfo().endCursor();
 					apolloClient.query(new IssueDataQuery(searchQuery, Input.fromNullable(nextCursor)))
 					.enqueue(this);
 				}
 				else {
-					logger.debug("Last page");
 					sink.emitComplete(FAIL_FAST);
 				}
 			}

--- a/src/main/java/io/spring/team/scorecard/graphql/GraphQLClient.java
+++ b/src/main/java/io/spring/team/scorecard/graphql/GraphQLClient.java
@@ -1,6 +1,11 @@
 package io.spring.team.scorecard.graphql;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloClient;
@@ -8,6 +13,10 @@ import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 import io.spring.team.scorecard.AssignableUsersQuery;
 import io.spring.team.scorecard.IssueCountQuery;
+import io.spring.team.scorecard.IssueDataQuery;
+import io.spring.team.scorecard.data.Issue;
+import io.spring.team.scorecard.type.IssueState;
+import io.spring.team.scorecard.type.PullRequestState;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -49,6 +58,84 @@ public class GraphQLClient {
 						}
 					});
 		});
+	}
+
+	public Flux<Issue> searchIssuesAndPRs(String searchQuery) {
+		logger.debug("query: " + searchQuery);
+		return Flux.create(sink -> {
+			this.apolloClient.query(new IssueDataQuery(searchQuery))
+					.enqueue(new ApolloCall.Callback<IssueDataQuery.Data>() {
+						@Override
+						public void onResponse(@NotNull Response<IssueDataQuery.Data> response) {
+							List<IssueDataQuery.Node> issues = response.getData().search().nodes();
+
+							logger.debug("processing " + issues.size() + " nodes, response indicated a total of " + response.getData().search().issueCount() + " matches");
+
+							issues.stream()
+									.peek(node -> {
+										if (!(node instanceof IssueDataQuery.AsIssue) && !(node instanceof IssueDataQuery.AsPullRequest)) {
+											logger.debug("Excluding element that is not an issue: " + node.getClass().getName() + ": " + node);
+										}
+									})
+									.filter(node -> node instanceof IssueDataQuery.AsIssue || node instanceof IssueDataQuery.AsPullRequest)
+									.map(issue -> issueFromNode(issue))
+									.forEach(sink::next);
+							sink.complete();
+						}
+
+						@Override
+						public void onFailure(@NotNull ApolloException e) {
+							sink.error(e);
+						}
+					});
+		});
+	}
+
+	@NotNull
+	private Issue issueFromNode(IssueDataQuery.Node node) {
+		if (node instanceof IssueDataQuery.AsIssue) {
+			return issueFromNodeIssue((IssueDataQuery.AsIssue) node);
+		}
+		if (node instanceof IssueDataQuery.AsPullRequest) {
+			return issueFromNodePr((IssueDataQuery.AsPullRequest) node);
+		}
+		throw new IllegalArgumentException("Unprocessable node: " + node);
+	}
+
+	private Issue issueFromNodeIssue(IssueDataQuery.AsIssue issue) {
+		int id = issue.number();
+		String author = issue.author().login();
+		LocalDateTime createdAt = LocalDateTime.parse(String.valueOf(issue.createdAt()), DateTimeFormatter.ISO_DATE_TIME);
+		boolean isOpen = issue.state() == IssueState.OPEN;
+		LocalDateTime closedAt = null;
+		if (issue.closedAt() != null) {
+			closedAt = LocalDateTime.parse(String.valueOf(issue.closedAt()), DateTimeFormatter.ISO_DATE_TIME);
+		}
+
+		List<String> labels = issue.labels().nodes().stream().map(IssueDataQuery.Node1::name).collect(Collectors.toList());
+		List<String> participants = issue.participants().nodes().stream().map(IssueDataQuery.Node2::login).collect(Collectors.toList());
+
+		String milestone = issue.milestone() == null ? null : issue.milestone().title();
+
+		return new Issue(id, author, createdAt, isOpen, closedAt, labels, participants, milestone);
+	}
+
+	private Issue issueFromNodePr(IssueDataQuery.AsPullRequest pr) {
+		int id = pr.number();
+		String author = pr.author().login();
+		LocalDateTime createdAt = LocalDateTime.parse(String.valueOf(pr.createdAt()), DateTimeFormatter.ISO_DATE_TIME);
+		boolean isOpen = pr.state() == PullRequestState.OPEN;
+		LocalDateTime closedAt = null;
+		if (pr.closedAt() != null) {
+			closedAt = LocalDateTime.parse(String.valueOf(pr.closedAt()), DateTimeFormatter.ISO_DATE_TIME);
+		}
+
+		List<String> labels = pr.labels().nodes().stream().map(IssueDataQuery.Node3::name).collect(Collectors.toList());
+		List<String> participants = pr.participants().nodes().stream().map(IssueDataQuery.Node4::login).collect(Collectors.toList());
+
+		String milestone = pr.milestone() == null ? null : pr.milestone().title();
+
+		return new Issue(id, author, createdAt, isOpen, closedAt, labels, participants, milestone);
 	}
 
 	public Flux<String> findAssignableUsers(String org, String repo) {

--- a/src/main/java/io/spring/team/scorecard/graphql/GraphQLClient.java
+++ b/src/main/java/io/spring/team/scorecard/graphql/GraphQLClient.java
@@ -1,14 +1,16 @@
 package io.spring.team.scorecard.graphql;
 
 import java.io.IOException;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloClient;
+import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Input;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 import io.spring.team.scorecard.AssignableUsersQuery;
@@ -25,6 +27,9 @@ import org.apache.commons.logging.LogFactory;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+import static reactor.core.publisher.Sinks.EmitFailureHandler.FAIL_FAST;
 
 public class GraphQLClient {
 
@@ -62,33 +67,62 @@ public class GraphQLClient {
 
 	public Flux<Issue> searchIssuesAndPRs(String searchQuery) {
 		logger.debug("query: " + searchQuery);
-		return Flux.create(sink -> {
-			this.apolloClient.query(new IssueDataQuery(searchQuery))
-					.enqueue(new ApolloCall.Callback<IssueDataQuery.Data>() {
-						@Override
-						public void onResponse(@NotNull Response<IssueDataQuery.Data> response) {
-							List<IssueDataQuery.Node> issues = response.getData().search().nodes();
+		Sinks.Many<Issue> sink = Sinks.many().unicast().onBackpressureBuffer();
+		AtomicInteger processed = new AtomicInteger(0);
 
-							logger.debug("processing " + issues.size() + " nodes, response indicated a total of " + response.getData().search().issueCount() + " matches");
+		ApolloCall.Callback<IssueDataQuery.Data> issueDataPaginatedCallback = new ApolloCall.Callback<IssueDataQuery.Data>() {
+			@Override
+			public void onResponse(@NotNull Response<IssueDataQuery.Data> response) {
+				if (response.hasErrors()) {
+					String messages = response.getErrors().stream().map(Error::getMessage).collect(Collectors.joining(", "));
+					sink.emitError(new IllegalStateException("Error in response: " + messages), FAIL_FAST);
+					return;
+				}
 
-							issues.stream()
-									.peek(node -> {
-										if (!(node instanceof IssueDataQuery.AsIssue) && !(node instanceof IssueDataQuery.AsPullRequest)) {
-											logger.debug("Excluding element that is not an issue: " + node.getClass().getName() + ": " + node);
-										}
-									})
-									.filter(node -> node instanceof IssueDataQuery.AsIssue || node instanceof IssueDataQuery.AsPullRequest)
-									.map(issue -> issueFromNode(issue))
-									.forEach(sink::next);
-							sink.complete();
-						}
+				final IssueDataQuery.Search search = response.getData().search();
 
-						@Override
-						public void onFailure(@NotNull ApolloException e) {
-							sink.error(e);
-						}
-					});
-		});
+				List<IssueDataQuery.Node> issues = search.nodes();
+				int issueCount = search.issueCount();
+				int start = processed.getAndAdd(issues.size());
+				int end = processed.get();
+				logger.info("Fetching issues " + start + ".." + end + "/" + issueCount);
+
+				emitIssues(issues, sink);
+
+				boolean hasMorePages = search.pageInfo().hasNextPage();
+				if (hasMorePages) {
+					logger.debug("Fetching additional page");
+					String nextCursor = search.pageInfo().endCursor();
+					apolloClient.query(new IssueDataQuery(searchQuery, Input.fromNullable(nextCursor)))
+					.enqueue(this);
+				}
+				else {
+					logger.debug("Last page");
+					sink.emitComplete(FAIL_FAST);
+				}
+			}
+
+			@Override
+			public void onFailure(@NotNull ApolloException e) {
+				sink.emitError(e, FAIL_FAST);
+			}
+		};
+		this.apolloClient.query(new IssueDataQuery(searchQuery, Input.absent()))
+					.enqueue(issueDataPaginatedCallback);
+
+		return sink.asFlux();
+	}
+
+	private void emitIssues(List<IssueDataQuery.Node> issues, Sinks.Many<Issue> sink) {
+		issues.stream()
+				.peek(node -> {
+					if (!(node instanceof IssueDataQuery.AsIssue) && !(node instanceof IssueDataQuery.AsPullRequest)) {
+						logger.debug("Excluding element that is not an issue: " + node.getClass().getName() + ": " + node);
+					}
+				})
+				.filter(node -> node instanceof IssueDataQuery.AsIssue || node instanceof IssueDataQuery.AsPullRequest)
+				.map(issue -> issueFromNode(issue))
+				.forEach(i -> sink.emitNext(i, FAIL_FAST));
 	}
 
 	@NotNull

--- a/src/main/java/io/spring/team/scorecard/stats/StatsService2.java
+++ b/src/main/java/io/spring/team/scorecard/stats/StatsService2.java
@@ -1,0 +1,55 @@
+package io.spring.team.scorecard.stats;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.spring.team.scorecard.data.Issue;
+import io.spring.team.scorecard.graphql.GraphQLClient;
+import io.spring.team.scorecard.graphql.SearchQueryBuilder;
+import reactor.core.publisher.Flux;
+
+/**
+ * @author Simon Baslé
+ */
+public class StatsService2 {
+
+	private final String org;
+
+	private final String repo;
+
+	private final GraphQLClient client;
+
+	public StatsService2(String org, String repo, GraphQLClient client) {
+		this.org = org;
+		this.repo = repo;
+		this.client = client;
+	}
+
+	public Flux<Issue> findAllIssuesCreatedBetween(LocalDate start, LocalDate end) {
+		String query = SearchQueryBuilder.create(this.org, this.repo)
+				.createdBetween(start, end)
+				.build();
+		return this.client.searchIssuesAndPRs(query);
+	}
+
+	public long teamCreated(List<Issue> issues, List<String> members) {
+		return issues.stream().filter(issue -> members.contains(issue.author)).count();
+	}
+
+	public long calculateInboundVolume(List<Issue> issues, List<String> members, List<String> bots) {
+		return issues.stream().filter(issue -> !members.contains(issue.author) && !bots.contains(issue.author)).count();
+	}
+
+	public long calculateOutputVolumeByType(List<Issue> issues, List<String> typeLabelsList) {
+		Set<String> typeLabels = new HashSet<>(typeLabelsList);
+		return issues.stream()
+				.filter(issue -> {
+					Set<String> labels = new HashSet<>(issue.labels);
+					labels.retainAll(typeLabels);
+					return !labels.isEmpty();
+				})
+				.count();
+	}
+}

--- a/src/main/java/io/spring/team/scorecard/stats/StatsService2.java
+++ b/src/main/java/io/spring/team/scorecard/stats/StatsService2.java
@@ -34,6 +34,13 @@ public class StatsService2 {
 		return this.client.searchIssuesAndPRs(query);
 	}
 
+	public Flux<Issue> findAllIssuesClosedBetween(LocalDate start, LocalDate end) {
+		String query = SearchQueryBuilder.create(this.org, this.repo)
+				.closedBetween(start, end)
+				.build();
+		return this.client.searchIssuesAndPRs(query);
+	}
+
 	public long teamCreated(List<Issue> issues, List<String> members) {
 		return issues.stream().filter(issue -> members.contains(issue.author)).count();
 	}
@@ -42,9 +49,14 @@ public class StatsService2 {
 		return issues.stream().filter(issue -> !members.contains(issue.author) && !bots.contains(issue.author)).count();
 	}
 
-	public long calculateOutputVolumeByType(List<Issue> issues, List<String> typeLabelsList) {
+	/**
+	 * @param closedIssues the list of issues that were closed during the period
+	 * @param typeLabelsList the labels to consider (OR)
+	 * @return
+	 */
+	public long calculateOutputVolumeByType(List<Issue> closedIssues, List<String> typeLabelsList) {
 		Set<String> typeLabels = new HashSet<>(typeLabelsList);
-		return issues.stream()
+		return closedIssues.stream()
 				.filter(issue -> {
 					Set<String> labels = new HashSet<>(issue.labels);
 					labels.retainAll(typeLabels);


### PR DESCRIPTION
This PR explores an alternative service for workloads stats that is based on a single GraphQL query fetching rich data about issues between `start` and `end`, then performing aggregations in memory on the returned list.